### PR TITLE
Add HACS init container to Home Assistant

### DIFF
--- a/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
+++ b/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
@@ -30,8 +30,9 @@ spec:
             - -c
             - |
               set -eu
-              if [ -f /config/custom_components/hacs/hacs.json ]; then
-                echo "HACS already installed; skipping."
+              installed=$(awk -F'"' '/"version"/{print $4; exit}' /config/custom_components/hacs/manifest.json 2>/dev/null || echo "")
+              if [ "$installed" = "$HACS_VERSION" ]; then
+                echo "HACS ${HACS_VERSION} already installed; skipping."
                 exit 0
               fi
               echo "Installing HACS ${HACS_VERSION}..."

--- a/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
+++ b/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
         - name: install-hacs
-          image: "alpine:3.20"
+          image: "alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc"
           env:
             - name: HACS_VERSION
               # renovate: datasource=github-releases depName=hacs/integration

--- a/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
+++ b/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               apk add --no-cache curl unzip >/dev/null
               mkdir -p /config/custom_components/hacs
               tmp=$(mktemp -d)
-              curl -fsSL -o "${tmp}/hacs.zip" \
+              curl -fsSL --max-time 60 -o "${tmp}/hacs.zip" \
                 "https://github.com/hacs/integration/releases/download/${HACS_VERSION}/hacs.zip"
               unzip -q -o "${tmp}/hacs.zip" -d /config/custom_components/hacs
               rm -rf "${tmp}"

--- a/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
+++ b/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
@@ -18,6 +18,34 @@ spec:
       labels:
         app: home-assistant
     spec:
+      initContainers:
+        - name: install-hacs
+          image: "alpine:3.20"
+          env:
+            # renovate: datasource=github-releases depName=hacs/integration
+            - name: HACS_VERSION
+              value: "2.0.5"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              if [ -f /config/custom_components/hacs/hacs.json ]; then
+                echo "HACS already installed; skipping."
+                exit 0
+              fi
+              echo "Installing HACS ${HACS_VERSION}..."
+              apk add --no-cache curl unzip >/dev/null
+              mkdir -p /config/custom_components/hacs
+              tmp=$(mktemp -d)
+              curl -fsSL -o "${tmp}/hacs.zip" \
+                "https://github.com/hacs/integration/releases/download/${HACS_VERSION}/hacs.zip"
+              unzip -q -o "${tmp}/hacs.zip" -d /config/custom_components/hacs
+              rm -rf "${tmp}"
+              echo "HACS ${HACS_VERSION} installed."
+          volumeMounts:
+            - name: ha-config-root
+              mountPath: /config
       containers:
         - name: home-assistant-app
           image: "ghcr.io/home-assistant/home-assistant:2026.5.2"

--- a/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
+++ b/pi-cluster/cluster/apps/home-assistant/home-assistant/deployment.yaml
@@ -22,8 +22,8 @@ spec:
         - name: install-hacs
           image: "alpine:3.20"
           env:
-            # renovate: datasource=github-releases depName=hacs/integration
             - name: HACS_VERSION
+              # renovate: datasource=github-releases depName=hacs/integration
               value: "2.0.5"
           command:
             - /bin/sh


### PR DESCRIPTION
## Summary

- Adds an `install-hacs` init container to the Home Assistant deployment that idempotently installs HACS (Home Assistant Community Store) into the NFS-backed config volume on pod start
- Pins the HACS version (`2.0.5`) with a Renovate annotation so update PRs are opened automatically
- Enables custom integrations (Hive replacement, Octopus Energy) to be installed and updated via the HACS UI rather than by manually copying files

## Test plan

- [ ] Apply the manifest and confirm the init container completes without error on a fresh config volume (`/config/custom_components/hacs/` populated)
- [ ] Restart the pod and confirm the init container skips installation (idempotency guard on `hacs.json`)
- [ ] Confirm Home Assistant starts successfully and HACS appears as an available integration in the HA UI
- [ ] Confirm Renovate detects the `hacs/integration` version annotation and can open bump PRs

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)