### PR TITLE
Set up Alertmanager to route alerts to #pi-alerts Slack channel

### DIFF
--- a/pi-cluster/cluster/apps/monitoring/prometheus/helm-release.yaml
+++ b/pi-cluster/cluster/apps/monitoring/prometheus/helm-release.yaml
@@ -27,6 +27,38 @@ spec:
           enabled: false
     alertmanager:
       enabled: true
+      alertmanagerSpec:
+        secrets:
+          - alertmanager-slack-webhook
+      config:
+        route:
+          group_by: ["alertname", "namespace"]
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 4h
+          receiver: "null"
+          routes:
+            - receiver: "null"
+              matchers:
+                - alertname = "Watchdog"
+            - receiver: "slack-pi-alerts"
+              matchers:
+                - severity =~ "warning|critical"
+        inhibit_rules:
+          - source_matchers:
+              - severity = critical
+            target_matchers:
+              - severity =~ warning|info
+            equal:
+              - namespace
+              - alertname
+        receivers:
+          - name: "null"
+          - name: "slack-pi-alerts"
+            slack_configs:
+              - api_url_file: /etc/alertmanager/secrets/alertmanager-slack-webhook/url
+                channel: "#pi-alerts"
+                send_resolved: true
     nodeExporter:
       enabled: true
     prometheus-node-exporter:

--- a/pi-cluster/cluster/apps/monitoring/prometheus/kustomization.yaml
+++ b/pi-cluster/cluster/apps/monitoring/prometheus/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - helm-release.yaml
   - volumes.yaml
   - ingress.yaml
+  - slack-webhook-secret.yaml

--- a/pi-cluster/cluster/apps/monitoring/prometheus/slack-webhook-secret.yaml
+++ b/pi-cluster/cluster/apps/monitoring/prometheus/slack-webhook-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-slack-webhook
+  namespace: monitoring
+stringData:
+  url: ${FLUX_SLACK_URL}


### PR DESCRIPTION
## Summary

- Creates a `alertmanager-slack-webhook` Secret in the `monitoring` namespace that materialises `${FLUX_SLACK_URL}` from `cluster-secrets`, giving Alertmanager a file-mounted webhook URL
- Configures Alertmanager with a Slack receiver targeting `#pi-alerts`, routing `warning` and `critical` severity alerts and suppressing the `Watchdog` heartbeat alert
- Restores the `inhibit_rules` block (suppresses `warning`/`info` when a `critical` is active for the same incident) that would otherwise be lost when `alertmanager.config` is set explicitly

Closes #671

## Test plan

- [ ] Create the `#pi-alerts` Slack channel if it doesn't exist yet
- [ ] After Flux reconciles, confirm Alertmanager pod is running in the `monitoring` namespace
- [ ] Trigger a test alert (e.g. temporarily scale a deployment to 0 to fire a `KubeDeploymentReplicasMismatch` warning) and verify a notification appears in `#pi-alerts`
- [ ] Confirm the `Watchdog` alert does not produce any Slack messages
- [ ] Confirm an `info`-severity alert (if one fires) does not appear in `#pi-alerts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)